### PR TITLE
Stimulus/stimulusFcn.m updated to use a .* in place of *

### DIFF
--- a/Stimulus/stimulusFcn.m
+++ b/Stimulus/stimulusFcn.m
@@ -137,7 +137,7 @@ for b = 1:length(s.fc(a,:))       % For each component of the section
             end
             xb = xb.*AM;
         case 'pls' %DH added for use with midi
-            xb = exp(4*sin(2*pi*fc*t))/exp(4.05);
+            xb = exp(4*sin(2*pi*fc.*t))/exp(4.05); % AU: changed to .* 10/20/22
             s.sc = -1;
         otherwise
             error('Unknown carrier wave type');


### PR DESCRIPTION
### Summary
Ran into a minor error when attempting to run the companion GrFNNRhythm repo's GUI: https://github.com/MusicDynamicsLab/GrFNNRhythm/blob/master/rhythmUI.m

This GUI calls https://github.com/MusicDynamicsLab/GrFNNToolbox/blob/master/Stimulus/stimulusFcn.m which errors out because of a * operator: the fix was to change it to .* and that works just fine.

### Failing condition
![Screen Shot 2022-10-20 at 4 23 56 PM](https://user-images.githubusercontent.com/11545977/197079583-8cfd5171-66b2-4f33-8945-e5d898f309cf.png)

### Error message
```
Error using  * 
Incorrect dimensions for matrix multiplication. Check that the
number of columns in the first matrix matches the number of rows
in the second matrix. To perform elementwise multiplication, use
'.*'.

Error in stimulusFcn (line 140)
            xb = exp(4*sin(2*pi*fc*t))/exp(4.05);

Error in stimulusMake>makeFcnInput (line 231)
    temp = stimulusFcn(t, s, a);  %quicker to write temp vector
    than keep indexing into s.x

Error in stimulusMake>makeMidiInput (line 537)
        note = makeFcnInput(s, [0 (N(n,7)-s.dt)], s.fs,
        out_type, freq(n), dB2Pa(N(n,5)));

Error in stimulusMake (line 191)
        s = makeMidiInput(s, temp{:});

Error in rhythmUI>integrate (line 168)
s = stimulusMake(1, 'mid', filename, [0 32.5], Fs, 'display',
2);

Error in rhythmUI>runStop (line 143)
    integrate(stimulus,model,handles);
 
Error while evaluating UIControl Callback.
```
### After applying fix 
![Screen Shot 2022-10-20 at 4 25 17 PM](https://user-images.githubusercontent.com/11545977/197079551-3096a0c6-7578-4c0b-bba1-9e935f7833cb.png)

